### PR TITLE
explicitly specify message encoding type

### DIFF
--- a/logstash/conf.d/30-waf-logs-full-logstash.conf
+++ b/logstash/conf.d/30-waf-logs-full-logstash.conf
@@ -1,6 +1,9 @@
 input {
   syslog {
     port => 5144
+    codec => plain {
+      charset => "ISO-8859-1"
+    }
   }
 }
 filter {


### PR DESCRIPTION
Need to explicitly specify a message encoding type to prevent logstash from trying to decode WAF events that contain alternate encodings such as UTF-8 in them.